### PR TITLE
Quickfix for currency conversion

### DIFF
--- a/usage-subscription-template/shopifyShop/actions/subscribe.js
+++ b/usage-subscription-template/shopifyShop/actions/subscribe.js
@@ -44,9 +44,15 @@ export async function run({
       planMatch.trialDays
     );
 
-    let price = 0;
+    let price = planMatch.pricePerOrder;
 
-    if (planMatch.pricePerOrder) {
+    if (price <= 0) {
+      throw new Error(
+        "INVALID PLAN PRICE - Plan price must be a positive non-zero number"
+      );
+    }
+
+    if (planMatch.currency !== record.currency) {
       const currencyConverter = new CurrencyConverter();
       // Get cost of plan for current shop based on the plan currency
       price = await currencyConverter


### PR DESCRIPTION
I saw that I had forgotten to update the currency conversion code to not be run on every subscription change. This PR rectifies that mistake