### PR TITLE
Github actions - easier development

### DIFF
--- a/.github/workflows/ai-screenwriter-template.yaml
+++ b/.github/workflows/ai-screenwriter-template.yaml
@@ -1,0 +1,20 @@
+name: CI/CD Pipeline
+
+on:
+  push:
+    paths:
+      - "ai-screenwriter-template/**"
+    branches:
+      - main
+
+jobs:
+  push-to-development-environment:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout the current repository
+        uses: actions/checkout@v4
+      - name: Push to development environment
+        run: npx ggt push --app=ai-screenwriter-template --env=development --force --allow-unknown-directory
+        working-directory: ai-screenwriter-template/
+        env:
+          GGT_TOKEN: ${{ secrets.AI_SCREENWRITER_DEPLOY_TOKEN }}

--- a/.github/workflows/airtable-template.yaml
+++ b/.github/workflows/airtable-template.yaml
@@ -1,0 +1,20 @@
+name: CI/CD Pipeline
+
+on:
+  push:
+    paths:
+      - "airtable-template/**"
+    branches:
+      - main
+
+jobs:
+  push-to-development-environment:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout the current repository
+        uses: actions/checkout@v4
+      - name: Push to development environment
+        run: npx ggt push --app=airtable-template --env=development --force --allow-unknown-directory
+        working-directory: airtable-template/
+        env:
+          GGT_TOKEN: ${{ secrets.AIRTABLE_DEPLOY_TOKEN }}

--- a/.github/workflows/bundle-template.yaml
+++ b/.github/workflows/bundle-template.yaml
@@ -1,0 +1,20 @@
+name: CI/CD Pipeline
+
+on:
+  push:
+    paths:
+      - "bundle-template/**"
+    branches:
+      - main
+
+jobs:
+  push-to-development-environment:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout the current repository
+        uses: actions/checkout@v4
+      - name: Push to development environment
+        run: npx ggt push --app=bundle-template --env=development --force --allow-unknown-directory
+        working-directory: bundle-template/
+        env:
+          GGT_TOKEN: ${{ secrets.BUNDLE_DEPLOY_TOKEN }}

--- a/.github/workflows/carrier-service-template.yaml
+++ b/.github/workflows/carrier-service-template.yaml
@@ -1,0 +1,20 @@
+name: CI/CD Pipeline
+
+on:
+  push:
+    paths:
+      - "carrier-service-template/**"
+    branches:
+      - main
+
+jobs:
+  push-to-development-environment:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout the current repository
+        uses: actions/checkout@v4
+      - name: Push to development environment
+        run: npx ggt push --app=carrier-service-template --env=development --force --allow-unknown-directory
+        working-directory: carrier-service-template/
+        env:
+          GGT_TOKEN: ${{ secrets.CARRIER_SERVICE_DEPLOY_TOKEN }}

--- a/.github/workflows/chatgpt-template.yaml
+++ b/.github/workflows/chatgpt-template.yaml
@@ -1,0 +1,20 @@
+name: CI/CD Pipeline
+
+on:
+  push:
+    paths:
+      - "chatgpt-template/**"
+    branches:
+      - main
+
+jobs:
+  push-to-development-environment:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout the current repository
+        uses: actions/checkout@v4
+      - name: Push to development environment
+        run: npx ggt push --app=chatgpt-template --env=development --force --allow-unknown-directory
+        working-directory: chatgpt-template/
+        env:
+          GGT_TOKEN: ${{ secrets.CHATGPT_DEPLOY_TOKEN }}

--- a/.github/workflows/pre-purchase-template.yaml
+++ b/.github/workflows/pre-purchase-template.yaml
@@ -1,0 +1,20 @@
+name: CI/CD Pipeline
+
+on:
+  push:
+    paths:
+      - "pre-purchase-template/**"
+    branches:
+      - main
+
+jobs:
+  push-to-development-environment:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout the current repository
+        uses: actions/checkout@v4
+      - name: Push to development environment
+        run: npx ggt push --app=pre-purchase-template --env=development --force --allow-unknown-directory
+        working-directory: pre-purchase-template/
+        env:
+          GGT_TOKEN: ${{ secrets.PRE_PURCHASE_DEPLOY_TOKEN }}

--- a/.github/workflows/product-quiz-template.yaml
+++ b/.github/workflows/product-quiz-template.yaml
@@ -1,0 +1,20 @@
+name: CI/CD Pipeline
+
+on:
+  push:
+    paths:
+      - "product-quiz-template/**"
+    branches:
+      - main
+
+jobs:
+  push-to-development-environment:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout the current repository
+        uses: actions/checkout@v4
+      - name: Push to development environment
+        run: npx ggt push --app=product-quiz-template --env=development --force --allow-unknown-directory
+        working-directory: product-quiz-template/
+        env:
+          GGT_TOKEN: ${{ secrets.PRODUCT_QUIZ_DEPLOY_TOKEN }}

--- a/.github/workflows/product-tagger-template.yaml
+++ b/.github/workflows/product-tagger-template.yaml
@@ -1,0 +1,20 @@
+name: CI/CD Pipeline
+
+on:
+  push:
+    paths:
+      - "product-tagger-template/**"
+    branches:
+      - main
+
+jobs:
+  push-to-development-environment:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout the current repository
+        uses: actions/checkout@v4
+      - name: Push to development environment
+        run: npx ggt push --app=product-tagger-template --env=development --force --allow-unknown-directory
+        working-directory: product-tagger-template/
+        env:
+          GGT_TOKEN: ${{ secrets.PRODUCT_TAGGER_DEPLOY_TOKEN }}

--- a/.github/workflows/sales-tracker-template.yaml
+++ b/.github/workflows/sales-tracker-template.yaml
@@ -1,0 +1,20 @@
+name: CI/CD Pipeline
+
+on:
+  push:
+    paths:
+      - "sales-tracker-template/**"
+    branches:
+      - main
+
+jobs:
+  push-to-development-environment:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout the current repository
+        uses: actions/checkout@v4
+      - name: Push to development environment
+        run: npx ggt push --app=sales-tracker-template --env=development --force --allow-unknown-directory
+        working-directory: sales-tracker-template/
+        env:
+          GGT_TOKEN: ${{ secrets.SALES_TRACKER_DEPLOY_TOKEN }}

--- a/.github/workflows/slack-notification-template.yaml
+++ b/.github/workflows/slack-notification-template.yaml
@@ -1,0 +1,20 @@
+name: CI/CD Pipeline
+
+on:
+  push:
+    paths:
+      - "slack-notification-template/**"
+    branches:
+      - main
+
+jobs:
+  push-to-development-environment:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout the current repository
+        uses: actions/checkout@v4
+      - name: Push to development environment
+        run: npx ggt push --app=slack-notification-template --env=development --force --allow-unknown-directory
+        working-directory: slack-notification-template/
+        env:
+          GGT_TOKEN: ${{ secrets.SLACK_NOTIFICATION_DEPLOY_TOKEN }}

--- a/.github/workflows/tailwind-css-template.yaml
+++ b/.github/workflows/tailwind-css-template.yaml
@@ -1,0 +1,20 @@
+name: CI/CD Pipeline
+
+on:
+  push:
+    paths:
+      - "tailwind-css-template/**"
+    branches:
+      - main
+
+jobs:
+  push-to-development-environment:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout the current repository
+        uses: actions/checkout@v4
+      - name: Push to development environment
+        run: npx ggt push --app=tailwind-css-template --env=development --force --allow-unknown-directory
+        working-directory: tailwind-css-template/
+        env:
+          GGT_TOKEN: ${{ secrets.TAILWIND_CSS_DEPLOY_TOKEN }}

--- a/.github/workflows/usage-subscription-template.yaml
+++ b/.github/workflows/usage-subscription-template.yaml
@@ -1,0 +1,20 @@
+name: CI/CD Pipeline
+
+on:
+  push:
+    paths:
+      - "usage-subscription-template/**"
+    branches:
+      - main
+
+jobs:
+  push-to-development-environment:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout the current repository
+        uses: actions/checkout@v4
+      - name: Push to development environment
+        run: npx ggt push --app=usage-subscription-template --env=development --force --allow-unknown-directory
+        working-directory: usage-subscription-template/
+        env:
+          GGT_TOKEN: ${{ secrets.USAGE_SUBSCRIPTION_DEPLOY_TOKEN }}


### PR DESCRIPTION
Adding most, if not all template's gh actions to push the PR data to dev.

This will help us develop and "deploy" our changes to the templates so that users can get the most up to date template code.